### PR TITLE
Accept a broader range of offsets in tracking mode

### DIFF
--- a/es100_wwvb.py
+++ b/es100_wwvb.py
@@ -636,7 +636,7 @@ class es100_wwvb:
                                         if rx_timestamp_frac > .75:
                                                 wwvb_time_secs = int(rx_timestamp + 1)
                                         else:
-                                                wwvb_time_secds = int(rx_timestamp)
+                                                wwvb_time_secs = int(rx_timestamp)
                                         txt = "read_rx_wwvb_device: accept timestamp for :{} second offset"
                                         print txt.format(int(rx_timestamp_mod))
                                 else:

--- a/es100_wwvb.py
+++ b/es100_wwvb.py
@@ -629,32 +629,24 @@ class es100_wwvb:
                         # when in tracking mode,
                         # only accept timestamps which are within +/- 250 milliseconds from expected ts.
                         #
-                        # TODO(pgenera): added 19s, but this is very consistently 19s. It can be +/-4s according to the datasheet and still be valid.
-                        if rx_timestamp_mod >= 18.750 and rx_timestamp_mod < 19.250:
-                                if rx_timestamp_mod < 19:
-                                        wwvb_time_secs = int(rx_timestamp + 1)
+                        # ts can be :55 + ~24.5, +/-4s according to the datasheet and still be valid.
+                        # :19.5 +/- 4 = :15 to :23:
+                        if rx_timestamp_mod >= 15 and rx_timestamp_mod <= 24:
+                                if rx_timestamp_frac > .75 or rx_timestamp_frac < .25:
+                                        if rx_timestamp_frac > .75:
+                                                wwvb_time_secs = int(rx_timestamp + 1)
+                                        else:
+                                                wwvb_time_secds = int(rx_timestamp)
+                                        txt = "read_rx_wwvb_device: accept timestamp for :{} second offset"
+                                        print txt.format(int(rx_timestamp_mod))
                                 else:
-                                        wwvb_time_secs = int(rx_timestamp)
-                                print "read_rx_wwvb_device: accept timestamp for :19 second offset"
-                        elif rx_timestamp_mod >= 19.750 and rx_timestamp_mod < 20.250:
-                                if rx_timestamp_mod < 20:
-                                        wwvb_time_secs = int(rx_timestamp + 1)
-                                else:
-                                        wwvb_time_secs = int(rx_timestamp)
-                                print "read_rx_wwvb_device: accept timestamp for :20 second offset"
-                        elif rx_timestamp_mod >= 20.750 and rx_timestamp_mod < 21.250:
-                                if rx_timestamp_mod < 21:
-                                        wwvb_time_secs = int(rx_timestamp + 1)
-                                else:
-                                        wwvb_time_secs = int(rx_timestamp)
-                                print "read_rx_wwvb_device: accept timestamp for :21 second offset"
-                        else:
-                                print "read_rx_wwvb_device: tracking sample offset out of range"
-                                print "read_rx_wwvb_device: clock offset in tracking mode exceeds 250 ms, forcing full RX"
-                                self.disable_wwvb_device()
-                                self.wwvb_emit_clockstats(es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE, rx_ant, rx_timestamp)
-                                self.force_full_rx = True
-                                return es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE
+                                        # out of +/-250ms range
+                                        print "read_rx_wwvb_device: tracking sample offset out of range"
+                                        print "read_rx_wwvb_device: clock offset in tracking mode exceeds 250 ms, forcing full RX"
+                                        self.disable_wwvb_device()
+                                        self.wwvb_emit_clockstats(es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE, rx_ant, rx_timestamp)
+                                        self.force_full_rx = True
+                                        return es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE
                 else:
                         rx_mode = "FULL"
                         print "read_rx_wwvb_device: status0 reg: processing normal RX mode"

--- a/es100_wwvb.py
+++ b/es100_wwvb.py
@@ -629,26 +629,32 @@ class es100_wwvb:
                         # when in tracking mode,
                         # only accept timestamps which are within +/- 250 milliseconds from expected ts.
                         #
-                        if rx_timestamp_mod >= 19.750 and rx_timestamp_mod < 20.250:
+                        # TODO(pgenera): added 19s, but this is very consistently 19s. It can be +/-4s according to the datasheet and still be valid.
+                        if rx_timestamp_mod >= 18.750 and rx_timestamp_mod < 19.250:
+                                if rx_timestamp_mod < 19:
+                                        wwvb_time_secs = int(rx_timestamp + 1)
+                                else:
+                                        wwvb_time_secs = int(rx_timestamp)
+                                print "read_rx_wwvb_device: accept timestamp for :19 second offset"
+                        elif rx_timestamp_mod >= 19.750 and rx_timestamp_mod < 20.250:
                                 if rx_timestamp_mod < 20:
                                         wwvb_time_secs = int(rx_timestamp + 1)
                                 else:
                                         wwvb_time_secs = int(rx_timestamp)
                                 print "read_rx_wwvb_device: accept timestamp for :20 second offset"
-                        else:
-                                if rx_timestamp_mod >= 20.750 and rx_timestamp_mod < 21.250:
-                                        if rx_timestamp_mod < 21:
-                                                wwvb_time_secs = int(rx_timestamp + 1)
-                                        else:
-                                                wwvb_time_secs = int(rx_timestamp)
-                                        print "read_rx_wwvb_device: accept timestamp for :21 second offset"
+                        elif rx_timestamp_mod >= 20.750 and rx_timestamp_mod < 21.250:
+                                if rx_timestamp_mod < 21:
+                                        wwvb_time_secs = int(rx_timestamp + 1)
                                 else:
-                                        print "read_rx_wwvb_device: tracking sample offset out of range"
-                                        print "read_rx_wwvb_device: clock offset in tracking mode exceeds 250 ms, forcing full RX"
-                                        self.disable_wwvb_device()
-                                        self.wwvb_emit_clockstats(es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE, rx_ant, rx_timestamp)
-                                        self.force_full_rx = True
-                                        return es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE
+                                        wwvb_time_secs = int(rx_timestamp)
+                                print "read_rx_wwvb_device: accept timestamp for :21 second offset"
+                        else:
+                                print "read_rx_wwvb_device: tracking sample offset out of range"
+                                print "read_rx_wwvb_device: clock offset in tracking mode exceeds 250 ms, forcing full RX"
+                                self.disable_wwvb_device()
+                                self.wwvb_emit_clockstats(es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE, rx_ant, rx_timestamp)
+                                self.force_full_rx = True
+                                return es100_wwvb.RX_STATUS_WWVB_T_STAMP_OORANGE
                 else:
                         rx_mode = "FULL"
                         print "read_rx_wwvb_device: status0 reg: processing normal RX mode"

--- a/update_shm_one_shot.c
+++ b/update_shm_one_shot.c
@@ -84,7 +84,7 @@ void update_shm(const struct timespec *pps_ts, const struct timespec *local_ts)
 {
 	struct shm_time *shm = get_shmseg();
 
-	printf("update_shm_ones_hot: shm->valid = %d, shm->count = %d, shm->nsamples = %d\n", shm->valid, shm->count, shm->nsamples);
+	printf("update_shm_one_shot: shm->valid = %d, shm->count = %d, shm->nsamples = %d\n", shm->valid, shm->count, shm->nsamples);
 	shm->valid = 0;
 	atomic_thread_fence(memory_order_seq_cst);
 	shm->mode = 1;


### PR DESCRIPTION
On my (new-style) es100 dev board from, I was consistently getting offsets of 19s in tracking mode, which were rejected. This broadens the accepted range to match my reading of the data sheet, and fixes a typo.

This revision has been running on tock.fivesevenfive.org (ipv6 only) for about a day now and seems to be working, feel free to poke the NTP server yourself if you want.